### PR TITLE
Cache all static files

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,9 @@ const server = app.listen(process.env.PORT || 9999, function() {
 });
 
 //Static files
-app.use(express.static("public"));
+app.use(express.static("public", {
+	maxAge: '1d', // Cache for a day
+}));
 
 //Socket setup
 const io = socket(server);


### PR DESCRIPTION
Previously it would redownload all assets on each page load,
and on iOS it would even redownload each card when your deck
updated. Now it caches all assets for 1 day.